### PR TITLE
feat: add permissions_boundary support for IAM role

### DIFF
--- a/modules/sfn-state-machine/iam.tf
+++ b/modules/sfn-state-machine/iam.tf
@@ -60,6 +60,8 @@ module "role" {
     var.iam_role.inline_policies,
   )
 
+  permissions_boundary = var.iam_role.permissions_boundary
+
   resource_group_enabled = false
   module_tags_enabled    = false
 

--- a/modules/sfn-state-machine/variables.tf
+++ b/modules/sfn-state-machine/variables.tf
@@ -80,6 +80,7 @@ variable "iam_role" {
     (Optional) `enabled` - Whether to create a default IAM role managed by this module.
     (Optional) `policies` - A list of IAM policies ARNs to attach to IAM role.
     (Optional) `inline_policies` - Map of inline IAM policies to attach to IAM role. (`name` => `policy`).
+    (Optional) `permissions_boundary` - The ARN of the IAM policy to use as permissions boundary for the default IAM role.
   EOF
   type = object({
     enabled = optional(bool, true)
@@ -88,8 +89,9 @@ variable "iam_role" {
       condition = string
       values    = list(string)
     })), [])
-    policies        = optional(list(string), [])
-    inline_policies = optional(map(string), {})
+    policies             = optional(list(string), [])
+    inline_policies      = optional(map(string), {})
+    permissions_boundary = optional(string)
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
## Summary

This PR adds `permissions_boundary` parameter support to IAM roles in modules that use the `terraform-aws-account` `iam-role` module. This allows users to configure IAM permissions boundaries for better security control.

## Changes

### modules/sfn-state-machine
- **iam.tf**: Added `permissions_boundary` parameter to `module "role"`
- **variables.tf**: Added `permissions_boundary = optional(string)` to `iam_role` variable

## Reference

This change follows the pattern established in: https://github.com/tedilabs/terraform-aws-security/commit/a65368004de7769c5bc281d255293c1c734743ed